### PR TITLE
Fix prepush command arg

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:env": "LOAD_ENV=1 yarn test",
     "test:ci": "yarn lint && yarn type-check && yarn test",
     "build": "tsc -p tsconfig.dist.json --declaration && cp README.md dist/README.md",
-    "prepush": "yarn lint && yarn type-check && jest --changedSince master"
+    "prepush": "yarn lint && yarn type-check && jest --changedSince main"
   },
   "peerDependencies": {
     "@jupiterone/integration-sdk-core": "^6.11.0"


### PR DESCRIPTION
A small fix before the version-1.0.0 PR is created - this prevented hooks on push from being successful and `HUSKY_SKIP_HOOKS=1` was necessary.